### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,5 +1,8 @@
 name: Django CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main","dev" ]


### PR DESCRIPTION
Potential fix for [https://github.com/awallenfang/household/security/code-scanning/2](https://github.com/awallenfang/household/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily interacts with repository contents (via `actions/checkout`) and does not modify them, the least privilege required is `contents: read`. This ensures the workflow can read repository contents without granting unnecessary write access.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. Alternatively, it can be added to the specific job (`build`), but the root-level approach is cleaner and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
