### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/awallenfang/household/security/code-scanning/1](https://github.com/awallenfang/household/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs linting operations, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to read the repository contents without granting write access. This block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
